### PR TITLE
Staple node-ssdp version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "wemo",
   "dependencies": {
-	"node-ssdp": "*",
+	"node-ssdp": "0.2.1",
 	"request": "*",
 	"xml2js": "*"
   },


### PR DESCRIPTION
node-ssdp updated to 1.0.0 and the API was changed. Asking for 0.2.1 will fix the problem until node-wemo is updated to use the new API.
